### PR TITLE
make cover, our services and service stats section responsive for  mobile 480px and less 

### DIFF
--- a/src/components/Cover.js
+++ b/src/components/Cover.js
@@ -7,8 +7,8 @@ function Cover() {
       <CoverBody>
         <CoverTitle>Your Imagination Is</CoverTitle>
         <CoverTitle>Your Only Limit</CoverTitle>
-        <CoverTextu>We always try to make our customer Happy. We provide all kind of facilities.</CoverTextu>
-        <CoverText>Your Satisfaction is our main priority</CoverText>
+        <CoverTextu>We always try to make our customer happy. We provide all kind of facilities.</CoverTextu>
+        <CoverText>Your satisfaction is our main priority</CoverText>
         <CoverButton href='/'>Discover More</CoverButton>
       </CoverBody>
       <BottomFade />
@@ -21,6 +21,7 @@ export default Cover
 const Container = styled.div`
   display: flex;
   flex-direction: column;
+  
 `
 
 const CoverImg = styled.img`
@@ -47,6 +48,9 @@ const CoverBody = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  text-align: center;
+  padding: 0 16px;
+  
 
 `
 const CoverTitle = styled.div`

--- a/src/components/Service.js
+++ b/src/components/Service.js
@@ -47,15 +47,18 @@ const Container = styled.div`
   height: 60vh;
   padding-top: 1vh;
   cursor: pointer;
+  align-items: center;
 `
 
 const ServiceTitle = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  text-align: center;
   padding-top: 7vh;
   font-weight: 600;
-  font-size: 3vh;
+  font-size: 30px;
+  color: rgb(240, 240, 240);
 `
 
 const ServiceCardContainer = styled.div`
@@ -63,4 +66,8 @@ const ServiceCardContainer = styled.div`
     display: flex;
     width: 100%;
     justify-content: space-evenly;
+    @media (max-width: 480px) {
+        display: grid;
+        padding: 0 32px;
+      }
 `

--- a/src/components/Service.js
+++ b/src/components/Service.js
@@ -48,6 +48,11 @@ const Container = styled.div`
   padding-top: 1vh;
   cursor: pointer;
   align-items: center;
+  @media (max-width: 480px) {
+    height: 100%;
+    align-content: center;
+    justify-content: center;
+}
 `
 
 const ServiceTitle = styled.div`

--- a/src/components/ServiceCard.js
+++ b/src/components/ServiceCard.js
@@ -34,6 +34,15 @@ const Container = styled.div`
   -webkit-box-shadow: -3px 22px 38px -9px rgba(156, 156, 156, 1);
   -moz-box-shadow: -3px 22px 38px -9px rgba(156, 156, 156, 1);
   box-shadow: -3px 22px 38px -9px rgba(156, 156, 156, 1);
+}
+@media (max-width: 480px) {
+        text-align: center;
+        padding: 8px;
+        margin-bottom: 16px;
+        width: 100%;
+        // height: 100%;6
+        display: grid;
+      }
 `;
 
 const ContainerInactive = styled.div`
@@ -56,11 +65,24 @@ const ContainerInactive = styled.div`
       -6px 6px 20px rgba(88, 88, 88, 0.16),
       -6px -6px 20px rgba(88, 88, 88, 0.16), 6px 6px 20px rgba(88, 88, 88, 0.16);
   }
+  }
+  @media (max-width: 480px) {
+    text-align: center;
+    padding: 8px;
+    margin-bottom: 16px;
+    width: 100%;
+    // height: 100%;
+    display: grid;
+  }
 `;
 
 const Image = styled.img`
   width: 2vw;
   margin-bottom: 3vh;
+  @media (max-width: 480px) { 
+    width: 6.8vw;
+   
+  }
 `;
 
 const Title = styled.div`

--- a/src/components/ServiceCard.js
+++ b/src/components/ServiceCard.js
@@ -37,11 +37,14 @@ const Container = styled.div`
 }
 @media (max-width: 480px) {
         text-align: center;
+        justify-content: center;
+        align-items: center;
         padding: 8px;
         margin-bottom: 16px;
         width: 100%;
         // height: 100%;6
-        display: grid;
+        display: flex;
+        flex-direction: column;
       }
 `;
 
@@ -68,11 +71,14 @@ const ContainerInactive = styled.div`
   }
   @media (max-width: 480px) {
     text-align: center;
+    justify-content: center;
+    align-items: center;
     padding: 8px;
     margin-bottom: 16px;
     width: 100%;
     // height: 100%;
-    display: grid;
+    display: flex;
+    flex-direction: column;
   }
 `;
 

--- a/src/components/ServiceStats.js
+++ b/src/components/ServiceStats.js
@@ -28,12 +28,19 @@ const Container = styled.div`
     flex-direction: column;
     width: 100vw;
     height: 80vh;
+    @media (max-width: 480px) {
+      padding: 0 32px;
+      height: 100%;
+    }
 `
 
 const Background = styled.img`
   position: absolute;
   align-self: center;
   max-width: 100vw;
+  @media (max-width: 480px) {
+    width: 100%;
+  }
 `
 const CoverTitleu = styled.div` // cover title upper text
   margin-top: 10vh;
@@ -41,6 +48,10 @@ const CoverTitleu = styled.div` // cover title upper text
   font-weight: 600;
   font-size: 6vh;
   text-align: center;
+  @media (max-width: 480px) {
+    margin-top: 70px;
+    font-size: 24px;
+  }
 `
 
 const CoverTitle = styled.div`
@@ -48,11 +59,17 @@ const CoverTitle = styled.div`
   font-weight: 600;
   font-size: 6vh;
   text-align: center;
+  @media (max-width: 480px) {
+    
+  }
 `
 const CoverText = styled.div`
   font-size: 14px;
   color: black;
   text-align: center;
+  @media (max-width: 480px) {
+    
+  }
 `
 
 const CoverTextu = styled.div` // cover text upper
@@ -60,11 +77,21 @@ const CoverTextu = styled.div` // cover text upper
   color: black;
   padding-top: 5vh;
   text-align: center;
+  @media (max-width: 480px) {
+    position: absolute;
+  }
 `
 
 const StatsCards = styled.div`
   display: flex;
   flex: 1;
-  justify-content: space-evenly;
   align-items: center;
+  justify-content: space-evenly;
+  @media (max-width: 480px) {
+    margin-top: 50px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 10px;
+    text-align: center;
+  }
 `

--- a/src/components/StatsCard.js
+++ b/src/components/StatsCard.js
@@ -27,6 +27,10 @@ const Container = styled.div`
   box-shadow: 6px -6px 20px rgba(88, 88, 88, 0.16),
     -6px 6px 20px rgba(88, 88, 88, 0.16), -6px -6px 20px rgba(88, 88, 88, 0.16),
     6px 6px 20px rgba(88, 88, 88, 0.16);
+    @media (max-width: 480px) {
+      width: 100%;
+      height: 100%;
+    }
 `;
 
 const Image = styled.img`


### PR DESCRIPTION
I see some of the text colors have been changed to white. I can add the colors to the elements after I pull again from the repo when merge is completed

![gitCoverImg](https://user-images.githubusercontent.com/43627445/195988289-9d3c9ae5-9f93-4c70-b031-44198e439631.jpg)
![gitOurServices](https://user-images.githubusercontent.com/43627445/195988292-e87f5c62-5212-4bac-b967-287c043f17d0.jpg)
![gitServiceStats](https://user-images.githubusercontent.com/43627445/195988294-1da8d47f-0a68-4db5-963d-ebfe9ac6d221.jpg)
